### PR TITLE
Use system dependencies and update Chapel version

### DIFF
--- a/Mason.toml
+++ b/Mason.toml
@@ -1,3 +1,4 @@
+
 [brick]
 chplVersion = "2.7.0"
 license = "None"
@@ -7,6 +8,8 @@ version = "0.0.1"
 
 [dependencies]
 
-[external]
-arrow = "arrow@19.0.1"
+[system]
+arrow = "19.0.1"
+parquet = "19.0.1"
+
 

--- a/Mason.toml
+++ b/Mason.toml
@@ -3,7 +3,7 @@
 name = "Parquet"
 type = "library"
 version = "0.0.1"
-chplVersion = "2.7.0"
+chplVersion = "2.7.0..2.9.0"
 license = "None"
 source = "https://github.com/ShreyasKhandekar/Parquet"
 

--- a/Mason.toml
+++ b/Mason.toml
@@ -5,7 +5,7 @@ type = "library"
 version = "0.0.1"
 chplVersion = "2.7.0..2.9.0"
 license = "None"
-source = "https://github.com/ShreyasKhandekar/Parquet"
+source = "https://github.com/e-kayrakli/Parquet"
 
 [dependencies]
 

--- a/Mason.toml
+++ b/Mason.toml
@@ -1,10 +1,11 @@
 
 [brick]
-chplVersion = "2.7.0"
-license = "None"
 name = "Parquet"
 type = "library"
 version = "0.0.1"
+chplVersion = "2.7.0"
+license = "None"
+source = "https://github.com/ShreyasKhandekar/Parquet"
 
 [dependencies]
 

--- a/prereqs/cpp/Makefile
+++ b/prereqs/cpp/Makefile
@@ -45,4 +45,4 @@ $(OBJDIR)/%.o: $(SRCDIR)/%.cpp | $(OBJDIR)
 	$(CHPL_CXX) $(CXXFLAGS) -c $< -o $@
 
 clean:
-	rm -rf $(OBJDIR) $(BINDIR)
+	rm -rf $(OBJDIR)

--- a/prereqs/cpp/Makefile
+++ b/prereqs/cpp/Makefile
@@ -20,8 +20,8 @@ CXXFLAGS=-I$(INCDIR)
 
 # assumes spack-installed arrow
 # TODO error check: spack exists? arrow installed?
-ARROW_DIR=$(shell spack find --paths --no-groups arrow | cut -d\   -f3)
-CXXFLAGS+=-I$(ARROW_DIR)/include
+ARROW_DIR=$(shell spack find --format="{prefix}" arrow)
+CXXFLAGS+=-I$(ARROW_DIR)/include -std=c++17
 
 # also add the src directory to be able to include SharedEnums without
 # relative path. This path is relative to prereqs/cpp

--- a/src/Parquet.chpl
+++ b/src/Parquet.chpl
@@ -21,17 +21,17 @@ module Parquet {
   import FileSystem as FS;
   import Path;
 
-  extern var ARROWINT64: c_int;
-  extern var ARROWINT32: c_int;
-  extern var ARROWUINT64: c_int;
-  extern var ARROWUINT32: c_int;
-  extern var ARROWBOOLEAN: c_int;
-  extern var ARROWSTRING: c_int;
-  extern var ARROWFLOAT: c_int;
-  extern var ARROWLIST: c_int;
-  extern var ARROWDOUBLE: c_int;
-  extern var ARROWERROR: c_int;
-  extern var ARROWDECIMAL: c_int;
+  extern const ARROWINT64: c_int;
+  extern const ARROWINT32: c_int;
+  extern const ARROWUINT64: c_int;
+  extern const ARROWUINT32: c_int;
+  extern const ARROWBOOLEAN: c_int;
+  extern const ARROWFLOAT: c_int;
+  extern const ARROWSTRING: c_int;
+  extern const ARROWDOUBLE: c_int;
+  extern const ARROWLIST: c_int;
+  extern const ARROWDECIMAL: c_int;
+  extern const ARROWERROR: c_int;
 
 
   private config const defaultBatchSize = 8192;


### PR DESCRIPTION
Makes the following changes to make this less fragile:

- Switch to system dependencies instead of Spack (mason external is very unstable today)
- Update the Chapel version range to allow up to 2.9.0
- Apply C++17 standards in the Makefile
- Replace extern variables with extern constants for better type safety
- Update the Mason.toml file to include the source key enforced by mason