### PR TITLE
Support for multi-column writes and strings

### DIFF
--- a/Mason.toml
+++ b/Mason.toml
@@ -12,5 +12,3 @@ source = "https://github.com/e-kayrakli/Parquet"
 [system]
 arrow = "19.0.1"
 parquet = "19.0.1"
-
-

--- a/prereqs/cpp/include/WriteParquet.h
+++ b/prereqs/cpp/include/WriteParquet.h
@@ -32,6 +32,21 @@ extern "C" {
                                   const char* dsetname, int64_t numelems,
                                   int64_t rowGroupSize, int64_t dtype, int64_t compression,
                                   char** errMsg);
+
+  int createFileWriter(const char* filename, void* column_names,
+                       void* objTypes, void* datatypes, int64_t colnum,
+                       int64_t compression, void** outWriter, void** errMsg);
+  int closeFileWriter(void* wrapper, char** errMsg);
+
+  void* c_appendRowGroup(void* wrapper);
+
+  void* c_nextColumn(void* wrapper);
+
+  void c_writeBatch(void* ptr, void* ptr_arr, void* def_levels,
+                     void* rep_levels, int64_t batchSize);
+
+  void c_writeBatchString(void* ptr, int64_t len, uint8_t* ptr_arr, void* def_levels,
+                          void* rep_levels, int64_t batchSize);
   
   int c_writeMultiColToParquet(const char* filename, void* column_names, 
                                 void** ptr_arr, void** offset_arr, void* objTypes, void* datatypes,
@@ -60,4 +75,20 @@ extern "C" {
   
 #ifdef __cplusplus
 }
+
+class FileWriterWrapper {
+  public:
+  std::shared_ptr<arrow::io::FileOutputStream> outfile;
+  std::shared_ptr<parquet::schema::GroupNode> schema;
+  std::shared_ptr<parquet::WriterProperties> props;
+  std::shared_ptr<parquet::ParquetFileWriter> fileWriter;
+
+  FileWriterWrapper(std::shared_ptr<arrow::io::FileOutputStream> outfile,
+                    std::shared_ptr<parquet::schema::GroupNode> schema,
+                    std::shared_ptr<parquet::WriterProperties> props,
+                    std::shared_ptr<parquet::ParquetFileWriter> fileWriter)
+    : outfile(outfile), schema(schema), props(props), fileWriter(fileWriter) {}
+};
+
+
 #endif

--- a/prereqs/cpp/include/WriteParquet.h
+++ b/prereqs/cpp/include/WriteParquet.h
@@ -51,6 +51,12 @@ extern "C" {
                                       void* chpl_arr, const char* dsetname, int64_t numelems,
                                       int64_t rowGroupSize, int64_t dtype, int64_t compression,
                                       char** errMsg);
+
+  int c_writeMultiColNumericToParquet(const char* filename, void* column_names,
+                                      void** ptr_arr, void* objTypes,
+                                      void* datatypes, int64_t colnum,
+                                      int64_t numelems, int64_t rowGroupSize,
+                                      int64_t compression, char** errMsg);
   
 #ifdef __cplusplus
 }

--- a/prereqs/cpp/src/UtilParquet.cpp
+++ b/prereqs/cpp/src/UtilParquet.cpp
@@ -423,7 +423,7 @@ std::shared_ptr<parquet::schema::GroupNode> SetupSchema(void* column_names, void
         auto list = parquet::schema::GroupNode::Make("list", parquet::Repetition::REPEATED, {element});
         fields.push_back(parquet::schema::GroupNode::Make(cname_ptr[i], parquet::Repetition::OPTIONAL, {list}, parquet::ConvertedType::LIST));
       } else {
-        fields.push_back(parquet::schema::PrimitiveNode::Make(cname_ptr[i], parquet::Repetition::OPTIONAL, parquet::Type::BYTE_ARRAY, parquet::ConvertedType::NONE));
+        fields.push_back(parquet::schema::PrimitiveNode::Make(cname_ptr[i], parquet::Repetition::OPTIONAL, parquet::Type::BYTE_ARRAY, parquet::ConvertedType::UTF8));
       }
     }
   }

--- a/prereqs/cpp/src/WriteParquet.cpp
+++ b/prereqs/cpp/src/WriteParquet.cpp
@@ -623,8 +623,8 @@ void c_writeBatch(void* ptr, void* ptr_arr, void* def_levels,
                    void* rep_levels, int64_t batchSize) {
   auto genericWriter = static_cast<parquet::ColumnWriter*>(ptr);
 
-#define CASE(EN, KIND, TYPE) \
-case parquet::Type::EN: \
+#define CASE(CAP, KIND, TYPE) \
+case parquet::Type::CAP: \
       static_cast<parquet::KIND##Writer*>(ptr)->WriteBatch(batchSize, \
         (int16_t*)def_levels, (int16_t*)rep_levels, \
         (TYPE*)ptr_arr); break;

--- a/prereqs/cpp/src/WriteParquet.cpp
+++ b/prereqs/cpp/src/WriteParquet.cpp
@@ -604,7 +604,7 @@ int closeFileWriter(void* wrapper, char** errMsg) {
   auto fileWriterWrapper = (FileWriterWrapper*) wrapper;
   fileWriterWrapper->fileWriter->Close();
   ARROWSTATUS_OK(fileWriterWrapper->outfile->Close());
-  //delete fileWriterWrapper;
+  delete fileWriterWrapper;
 
   return 0;
 }

--- a/prereqs/cpp/src/WriteParquet.cpp
+++ b/prereqs/cpp/src/WriteParquet.cpp
@@ -560,6 +560,94 @@ int cpp_writeMultiColNumericToParquet(const char* filename, void* column_names,
   }
 }
 
+
+int createFileWriter(const char* filename, void* column_names,
+                     void* objTypes, void* datatypes, int64_t colnum,
+                     int64_t compression, void** outWriter, void** errMsg) {
+  try {
+    // initialize the file to write to
+    using FileClass = ::arrow::io::FileOutputStream;
+    std::shared_ptr<FileClass> out_file;
+    ARROWRESULT_OK(FileClass::Open(filename), out_file);
+
+    // Setup the parquet schema
+    std::shared_ptr<parquet::schema::GroupNode> schema = SetupSchema(column_names, objTypes, datatypes, colnum);
+
+    parquet::WriterProperties::Builder builder;
+    // assign the proper compression
+    if(compression == SNAPPY_COMP) {
+      builder.compression(parquet::Compression::SNAPPY);
+    } else if (compression == GZIP_COMP) {
+      builder.compression(parquet::Compression::GZIP);
+    } else if (compression == BROTLI_COMP) {
+      builder.compression(parquet::Compression::BROTLI);
+    } else if (compression == ZSTD_COMP) {
+      builder.compression(parquet::Compression::ZSTD);
+    } else if (compression == LZ4_COMP) {
+      builder.compression(parquet::Compression::LZ4);
+    }
+    std::shared_ptr<parquet::WriterProperties> props = builder.build();
+
+    std::shared_ptr<parquet::ParquetFileWriter> file_writer =
+      parquet::ParquetFileWriter::Open(out_file, schema, props);
+
+    FileWriterWrapper* wrapper = new FileWriterWrapper(out_file, schema, props, file_writer);
+    *outWriter = (void*)wrapper;
+    return 0;
+  } catch (const std::exception& e) {
+    *errMsg = strdup(e.what());
+    return ARROWERROR;
+  }
+}
+
+int closeFileWriter(void* wrapper, char** errMsg) {
+  auto fileWriterWrapper = (FileWriterWrapper*) wrapper;
+  fileWriterWrapper->fileWriter->Close();
+  ARROWSTATUS_OK(fileWriterWrapper->outfile->Close());
+  //delete fileWriterWrapper;
+
+  return 0;
+}
+
+void* c_appendRowGroup(void* wrapper) {
+  auto fileWriterWrapper = (FileWriterWrapper*) wrapper;
+  return (void*) fileWriterWrapper->fileWriter->AppendRowGroup();
+}
+
+void* c_nextColumn(void* wrapper) {
+  auto rg_writer = (parquet::RowGroupWriter*)wrapper;
+  return rg_writer->NextColumn();
+}
+
+void c_writeBatch(void* ptr, void* ptr_arr, void* def_levels,
+                   void* rep_levels, int64_t batchSize) {
+  auto genericWriter = static_cast<parquet::ColumnWriter*>(ptr);
+
+#define CASE(EN, KIND, TYPE) \
+case parquet::Type::EN: \
+      static_cast<parquet::KIND##Writer*>(ptr)->WriteBatch(batchSize, \
+        (int16_t*)def_levels, (int16_t*)rep_levels, \
+        (TYPE*)ptr_arr); break;
+
+  switch(genericWriter->type()) {
+    CASE(BOOLEAN, Bool, bool)
+    CASE(INT32, Int32, int32_t)
+    CASE(INT64, Int64, int64_t)
+    CASE(FLOAT, Float, float)
+    CASE(DOUBLE, Double, double)
+    default: assert(false);
+  }
+
+#undef CASE
+}
+
+void c_writeBatchString(void* ptr, int64_t len, uint8_t* ptr_arr, void* def_levels,
+                        void* rep_levels, int64_t batchSize) {
+  parquet::ByteArray value(len, ptr_arr);
+  auto writer = static_cast<parquet::ByteArrayWriter*>(ptr);
+  writer->WriteBatch(batchSize, (int16_t*)def_levels, (int16_t*)rep_levels, &value);
+}
+
 int cpp_writeMultiColToParquet(const char* filename, void* column_names,
                                void** ptr_arr, void** offset_arr,
                                void* objTypes, void* datatypes,

--- a/src/Parquet.chpl
+++ b/src/Parquet.chpl
@@ -743,7 +743,7 @@ module Parquet {
                                                           c_ptrTo(c_objTypes),
                                                           c_ptrTo(c_types),
                                                           colCount,
-                                                          c_ptrTo(sizes),
+                                                          sizes[0],
                                                           ROWGROUPS,
                                                           compression=0,
                                                           call.errMsg);

--- a/src/Parquet.chpl
+++ b/src/Parquet.chpl
@@ -100,6 +100,7 @@ module Parquet {
       when int(32) do return ARROWINT32;
       when uint(64) do return ARROWUINT64;
       when uint(32) do return ARROWUINT32;
+      when real do return ARROWDOUBLE;
       when bool do return ARROWBOOLEAN;
       when string do return ARROWSTRING;
       otherwise do compilerError("Unsupported Chapel type: ", t:string);
@@ -732,14 +733,14 @@ module Parquet {
 
     var colCount: int;
 
-    proc ref registerColumn(A: [?colDom] ?eltType, colName: string) {
+    proc ref registerColumn(const A: [?colDom] ?eltType, colName: string) {
       // TODO check domain alignment
 
       coforall (loc, localInfo) in zip(sharedDom.targetLocales(), info) {
         on loc {
           const ref localSubDom = A.localSubdomain();
 
-          var ptr = c_pointer_return(A[localSubDom.first]);
+          var ptr = c_pointer_return_const(A[localSubDom.first]);
 
           localInfo.pushBack(
               new pqWriteLocalChunkInfo(colName.localize().c_str(),
@@ -804,7 +805,8 @@ module Parquet {
 
             var rg_writer = writer.AppendRowGroup();
             for (data, kind) in zip(c_datas, c_types) {
-              if kind == ARROWINT64 || kind == ARROWUINT64 {
+              if kind == ARROWINT64 || kind == ARROWUINT64 ||
+                 kind == ARROWBOOLEAN || kind == ARROWDOUBLE {
                 var col_writer = rg_writer.NextColumn();
                 col_writer.WriteBatch(data, nil, nil, batchSize);
               } else if kind == ARROWSTRING {
@@ -826,7 +828,7 @@ module Parquet {
     }
   }
 
-  proc writeTable(filename, colNames, ref Arrs...) {
+  proc writeTable(filename, colNames, const Arrs...) {
     var op = new pqWriteOp(filename, Arrs[0].domain);
 
     for param i in 0..<Arrs.size do op.registerColumn(Arrs[i], colNames[i]);

--- a/src/Parquet.chpl
+++ b/src/Parquet.chpl
@@ -689,7 +689,7 @@ module Parquet {
 
     var colCount: int;
 
-    proc registerColumn(A: [?colDom] ?eltType, colName: string) {
+    proc ref registerColumn(A: [?colDom] ?eltType, colName: string) {
       // TODO check domain alignment
 
       coforall (loc, localInfo) in zip(sharedDom.targetLocales(), info) {
@@ -751,7 +751,7 @@ module Parquet {
     }
   }
 
-  proc writeTable(filename, colNames, Arrs...) {
+  proc writeTable(filename, colNames, ref Arrs...) {
     var op = new pqWriteOp(filename, Arrs[0].domain);
 
     for i in 0..<Arrs.size do op.registerColumn(Arrs[i], colNames[i]);

--- a/src/Parquet.chpl
+++ b/src/Parquet.chpl
@@ -723,6 +723,7 @@ module Parquet {
           var c_colNames: [colDom] c_ptrConst(c_char);
           var c_datas: [colDom] c_ptrConst(void);
           var c_types: [colDom] int;
+          var c_objTypes: [colDom] int = 1;
           var sizes: [colDom] int;
 
           for (colInfo,   c_colName,  c_data,  c_type,  size) in
@@ -739,6 +740,7 @@ module Parquet {
             call.retVal = c_writeMultiColNumericToParquet(c_filename,
                                                           c_ptrTo(c_colNames),
                                                           c_ptrTo(c_datas),
+                                                          c_ptrTo(c_objTypes),
                                                           c_ptrTo(c_types),
                                                           colCount,
                                                           c_ptrTo(sizes),

--- a/src/Parquet.chpl
+++ b/src/Parquet.chpl
@@ -34,6 +34,48 @@ module Parquet {
   extern const ARROWDECIMAL: c_int;
   extern const ARROWERROR: c_int;
 
+  class FileWriter {
+    var _wrapper : c_ptr(void);
+
+    proc AppendRowGroup() {
+      extern proc c_appendRowGroup(wrapper): c_ptr(void);
+
+      return new RowGroupWriter(c_appendRowGroup(_wrapper));
+    }
+
+    proc close() {
+      extern proc closeFileWriter(wrapper, errMsg): c_int;
+      manage new parquetCall(getL(), getR(), getM()) as call {
+        call.retVal = closeFileWriter(_wrapper, call.errMsg);
+      }
+    }
+  }
+
+  class RowGroupWriter {
+    var _ptr : c_ptr(void);
+
+    proc NextColumn() {
+      extern proc c_nextColumn(ptr): c_ptr(void);
+
+      return new ColumnWriter(c_nextColumn(_ptr));
+    }
+  }
+
+  class ColumnWriter {
+    var _ptr : c_ptr(void);
+
+    proc WriteBatch(values, defLevels, repLevels, numValues) {
+      extern proc c_writeBatch(ptr, values, defLevels, repLevels, numValues): c_int;
+
+      c_writeBatch(_ptr, values, defLevels, repLevels, numValues);
+    }
+
+    proc WriteString(len, cstr, defLevels, repLevels) {
+      extern proc c_writeBatchString(ptr, len, cstr, defLevels, repLevels, numValues): c_int;
+
+      c_writeBatchString(_ptr, len, cstr, defLevels, repLevels, 1);
+    }
+  }
 
   private config const defaultBatchSize = 8192;
   config const ROWGROUPS = 512*1024*1024 / numBytes(int); // 512 mb of int64
@@ -59,6 +101,7 @@ module Parquet {
       when uint(64) do return ARROWUINT64;
       when uint(32) do return ARROWUINT32;
       when bool do return ARROWBOOLEAN;
+      when string do return ARROWSTRING;
       otherwise do compilerError("Unsupported Chapel type: ", t:string);
     }
   }
@@ -696,9 +739,11 @@ module Parquet {
         on loc {
           const ref localSubDom = A.localSubdomain();
 
+          var ptr = c_pointer_return(A[localSubDom.first]);
+
           localInfo.pushBack(
               new pqWriteLocalChunkInfo(colName.localize().c_str(),
-                                        c_ptrTo(A[localSubDom.first]),
+                                        ptr,
                                         chplTypeToCType(eltType),
                                         localSubDom.size));
         }
@@ -708,11 +753,12 @@ module Parquet {
     }
 
     proc write() {
-      extern proc c_writeMultiColNumericToParquet(filename, column_names,
-                                                  ptr_arr, objTypes, datatypes,
-                                                  colnum, numelems,
-                                                  rowGroupSize, compression,
-                                                  errMsg): c_int;
+      extern proc createFileWriter(filename, column_names,
+                                   objTypes, datatypes,
+                                   colnum,
+                                   compression,
+                                   writer,
+                                   errMsg): c_int;
 
       coforall (loc, localInfo) in zip(sharedDom.targetLocales(), info) {
         on loc {
@@ -736,18 +782,45 @@ module Parquet {
           }
 
           const c_filename = filenameBase.localize().c_str();
+          var writer = new FileWriter();
           manage new parquetCall(getL(), getR(), getM()) as call {
-            call.retVal = c_writeMultiColNumericToParquet(c_filename,
-                                                          c_ptrTo(c_colNames),
-                                                          c_ptrTo(c_datas),
-                                                          c_ptrTo(c_objTypes),
-                                                          c_ptrTo(c_types),
-                                                          colCount,
-                                                          sizes[0],
-                                                          ROWGROUPS,
-                                                          compression=0,
-                                                          call.errMsg);
+            call.retVal = createFileWriter(c_filename,
+                                           c_ptrTo(c_colNames),
+                                           c_ptrTo(c_objTypes),
+                                           c_ptrTo(c_types),
+                                           colCount,
+                                           compression=0,
+                                           c_ptrTo(writer._wrapper),
+                                           call.errMsg);
           }
+
+          var numLeft = sizes[0];
+
+          // TODO:
+          // - implement other data types
+          // - implement SEGARRAY?
+          for i in 0..#numLeft by ROWGROUPS {
+            const batchSize = min(numLeft-i, ROWGROUPS);
+
+            var rg_writer = writer.AppendRowGroup();
+            for (data, kind) in zip(c_datas, c_types) {
+              if kind == ARROWINT64 || kind == ARROWUINT64 {
+                var col_writer = rg_writer.NextColumn();
+                col_writer.WriteBatch(data, nil, nil, batchSize);
+              } else if kind == ARROWSTRING {
+                var col_writer = rg_writer.NextColumn();
+                var def_level = 1;
+
+                var strs = data:c_ptrConst(string);
+                for i in 0..#batchSize {
+                  const ref str = strs[i];
+                  col_writer.WriteString(str.size, str.c_str(), c_ptrTo(def_level), nil);
+                }
+              }
+            }
+          }
+
+          writer.close();
         }
       }
     }
@@ -756,7 +829,7 @@ module Parquet {
   proc writeTable(filename, colNames, ref Arrs...) {
     var op = new pqWriteOp(filename, Arrs[0].domain);
 
-    for i in 0..<Arrs.size do op.registerColumn(Arrs[i], colNames[i]);
+    for param i in 0..<Arrs.size do op.registerColumn(Arrs[i], colNames[i]);
 
     op.write();
   }

--- a/src/Parquet.chpl
+++ b/src/Parquet.chpl
@@ -1,5 +1,6 @@
 module Parquet {
   use CTypes;
+  use BlockDist;
 
   enum CompressionType {
     NONE=0,
@@ -455,7 +456,7 @@ module Parquet {
         const myFilename = filenames[idx];
 
         var locDom = A.localSubdomain();
-        var locArr = A[locDom];
+        var locArr = A[locDom]; // Engin: why are we doing this??
 
         numElemsPerFile[idx] = locDom.size;
 
@@ -667,6 +668,95 @@ module Parquet {
                                            call.errMsg);
     }
     if call.err then throw call.err;
+  }
+
+  record pqWriteLocalChunkInfo {
+    var c_colName: c_ptrConst(c_char);
+    var c_data: c_ptrConst(void);
+    var c_type: int;
+    var size: int;
+  }
+
+  record pqWriteOp {
+
+    var filenameBase: string;
+    var sharedDom: domain(?);
+
+    // per locale store for pqWriteLocalChunkInfo
+    var info = blockDist.createArray(sharedDom.targetLocales().domain,
+                                     list(pqWriteLocalChunkInfo),
+                                     targetLocales=sharedDom.targetLocales());
+
+    var colCount: int;
+
+    proc registerColumn(A: [?colDom] ?eltType, colName: string) {
+      // TODO check domain alignment
+
+      coforall (loc, localInfo) in zip(sharedDom.targetLocales(), info) {
+        on loc {
+          const ref localSubDom = A.localSubdomain();
+
+          localInfo.pushBack(
+              new pqWriteLocalChunkInfo(colName.localize().c_str(),
+                                        c_ptrTo(A[localSubDom.first]),
+                                        chplTypeToCType(eltType),
+                                        localSubDom.size));
+        }
+      }
+
+      colCount += 1;
+    }
+
+    proc write() {
+      extern proc c_writeMultiColNumericToParquet(filename, column_names,
+                                                  ptr_arr, objTypes, datatypes,
+                                                  colnum, numelems,
+                                                  rowGroupSize, compression,
+                                                  errMsg): c_int;
+
+      coforall (loc, localInfo) in zip(sharedDom.targetLocales(), info) {
+        on loc {
+          assert(localInfo.size == colCount);
+
+          const colDom = {0..#colCount};
+
+          var c_colNames: [colDom] c_ptrConst(c_char);
+          var c_datas: [colDom] c_ptrConst(void);
+          var c_types: [colDom] int;
+          var sizes: [colDom] int;
+
+          for (colInfo,   c_colName,  c_data,  c_type,  size) in
+           zip(localInfo, c_colNames, c_datas, c_types, sizes) {
+
+             c_colName = colInfo.c_colName;
+             c_data = colInfo.c_data;
+             c_type = colInfo.c_type;
+             size = colInfo.size;
+          }
+
+          const c_filename = filenameBase.localize().c_str();
+          manage new parquetCall(getL(), getR(), getM()) as call {
+            call.retVal = c_writeMultiColNumericToParquet(c_filename,
+                                                          c_ptrTo(c_colNames),
+                                                          c_ptrTo(c_datas),
+                                                          c_ptrTo(c_types),
+                                                          colCount,
+                                                          c_ptrTo(sizes),
+                                                          ROWGROUPS,
+                                                          compression=0,
+                                                          call.errMsg);
+          }
+        }
+      }
+    }
+  }
+
+  proc writeTable(filename, colNames, Arrs...) {
+    var op = new pqWriteOp(filename, Arrs[0].domain);
+
+    for i in 0..<Arrs.size do op.registerColumn(Arrs[i], colNames[i]);
+
+    op.write();
   }
 
   /* This is the Chapel array-based interface */

--- a/test/basic.chpl
+++ b/test/basic.chpl
@@ -32,6 +32,36 @@ proc testMultiColWriteRead(test: borrowed Test) throws {
     readColumn(filePath, "Arr3", In);
     test.assertEqual(Arr3, In);
   }
+
+  manage new tempDir() as temp {
+    const doubleArr : [1..10] real = 42.0;
+    const boolArr : [1..10] bool = true;
+    const intArr : [1..10] int = 7;
+    const uintArr : [1..10] uint = 8;
+
+    const filePath = Path.joinPath(temp.path,
+                                   "variousTypes.parquet");
+
+    const names = ("DoubleArr", "BoolArr", "IntArr", "UintArr");
+    writeTable(filePath, colNames=names,
+                doubleArr, boolArr, intArr, uintArr);
+
+    var doubleIn: [1..10] real;
+    readColumn(filePath, "DoubleArr", doubleIn);
+    test.assertEqual(doubleArr, doubleIn);
+
+    var boolIn: [1..10] bool;
+    readColumn(filePath, "BoolArr", boolIn);
+    test.assertEqual(boolArr, boolIn);
+
+    var intIn: [1..10] int;
+    readColumn(filePath, "IntArr", intIn);
+    test.assertEqual(intArr, intIn);
+
+    var uintIn: [1..10] uint;
+    readColumn(filePath, "UintArr", uintIn);
+    test.assertEqual(uintArr, uintIn);
+  }
 }
 
 proc testDistributedWriteRead(test: borrowed Test) throws {

--- a/test/basic.chpl
+++ b/test/basic.chpl
@@ -10,6 +10,30 @@ import BlockDist.blockDist;
 config const n = 100;
 
 
+proc testMultiColWriteRead(test: borrowed Test) throws {
+  var Arr1, Arr2, Arr3: [1..10] int;
+  Arr1 = 1;
+  Arr2 = 2;
+  Arr3 = 3;
+
+  var In: [1..10] int;
+
+  manage new tempDir() as temp {
+    const filePath = Path.joinPath(temp.path,
+                                   "testMultiColWriteRead.parquet");
+
+    writeTable(filePath, colNames=("Arr1", "Arr2", "Arr3"),
+               Arr1, Arr2, Arr3);
+
+    readColumn(filePath, "Arr1", In);
+    assertEqual(Arr1, In);
+    readColumn(filePath, "Arr2", In);
+    assertEqual(Arr2, In);
+    readColumn(filePath, "Arr3", In);
+    assertEqual(Arr3, In);
+  }
+}
+
 proc testDistributedWriteRead(test: borrowed Test) throws {
   var ArrOut, ArrIn = blockDist.createArray(1..n, int);
 

--- a/test/basic.chpl
+++ b/test/basic.chpl
@@ -26,11 +26,11 @@ proc testMultiColWriteRead(test: borrowed Test) throws {
                Arr1, Arr2, Arr3);
 
     readColumn(filePath, "Arr1", In);
-    assertEqual(Arr1, In);
+    test.assertEqual(Arr1, In);
     readColumn(filePath, "Arr2", In);
-    assertEqual(Arr2, In);
+    test.assertEqual(Arr2, In);
     readColumn(filePath, "Arr3", In);
-    assertEqual(Arr3, In);
+    test.assertEqual(Arr3, In);
   }
 }
 

--- a/test/simple-strings.chpl
+++ b/test/simple-strings.chpl
@@ -1,0 +1,29 @@
+use UnitTest;
+use Parquet;
+use TestUtil;
+
+import Path;
+import FileSystem as FS;
+
+import BlockDist.blockDist;
+
+config const n = 100;
+
+proc testWriteRead(test: borrowed Test) throws {
+  var Arr1, Arr2, Arr3: [1..10] int;
+  Arr1 = 1;
+  Arr2 = 2;
+  Arr3 = 3;
+
+  var Arr4 : [1..10] string;
+  for i in 1..10 do 
+    Arr4[i] = "str" + i:string;
+
+  const filePath = Path.joinPath("./",
+                                 "my.parquet");
+
+  writeTable(filePath, colNames=("Arr1", "Arr2", "Arr3", "Arr4"),
+             Arr1, Arr2, Arr3, Arr4);
+}
+
+UnitTest.main();


### PR DESCRIPTION
This PR adds support for multicolumn writes to a parquet file, as well as support for writing strings.

To better support the writing of strings, it was easier to move some of the logic into Chapel where we had better understanding of the ``string`` type. This required some lightweight shims over void pointers, which are passed around to extern functions where they can be cast to the correct C++ type and invoked.

Multicolumn writes are handled by preprocessing the given arrays and storing the relevant metadata into records, which are later used to invoke the actual writes via the lightweight shims.