### PR TITLE
Add release workflows bump version

### DIFF
--- a/.github/workflows/bump-minor-version.yml
+++ b/.github/workflows/bump-minor-version.yml
@@ -1,0 +1,75 @@
+name: Bump minor version
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [Publish to mason registry]
+    types: [completed]
+
+jobs:
+  bump-minor:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Exit if branch exists
+      run: |
+        BRANCH_NAME="update-version"
+        if git ls-remote --heads origin $BRANCH_NAME | grep -q $BRANCH_NAME; then
+          echo "Branch $BRANCH_NAME already exists."
+          exit 1
+        fi
+    - name: Create a new branch
+      run: |
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config user.name "github-actions[bot]"
+        git checkout -b update-version
+        git push --set-upstream origin update-version
+    - name: Get version from Mason.toml
+      id: previous_version
+      uses: mikefarah/yq@v4
+      with:
+        cmd: yq .brick.version Mason.toml
+    - name: Bump Minor Version
+      id: bump_version
+      run: |
+        MAJOR=$(echo "$PREVIOUS_VERSION" | cut -d. -f1)
+        MINOR=$(echo "$PREVIOUS_VERSION" | cut -d. -f2)
+        NEW_MINOR=$((MINOR + 1))
+        NEW_VERSION="$MAJOR.$NEW_MINOR.0"
+        echo "New version: $NEW_VERSION"
+        echo "result=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+      env:
+        PREVIOUS_VERSION: ${{ steps.previous_version.outputs.result }}
+    - name: Update version in Mason.toml
+      uses: mikefarah/yq@v4
+      with:
+        cmd: yq -i '.brick.version="${{ steps.bump_version.outputs.result }}"' Mason.toml
+    - name: Get name from Mason.toml
+      id: package_name
+      uses: mikefarah/yq@v4
+      with:
+        cmd: yq .brick.name Mason.toml
+    - name: Update version in README.md
+      run: |
+        sed -i "s/mason add $NAME@[0-9]*\.[0-9]*\.[0-9]*/mason add $NAME@$NEW_VERSION/g" README.md
+      env:
+        NAME: ${{ steps.package_name.outputs.result }}
+        NEW_VERSION: ${{ steps.bump_version.outputs.result }}
+    - name: Commit and push changes
+      run: |
+        git add Mason.toml
+        git add README.md
+        git commit -m "Bump version to $NEW_VERSION"
+        git push origin update-version
+      env:
+        NEW_VERSION: ${{ steps.bump_version.outputs.result }}
+    - name: create pull request
+      run: >
+        gh pr create
+        -B main
+        -H update-version
+        --title 'Bump version for next release'
+        --body 'Bump the version in prep for next release'
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,76 @@
+name: Publish to mason registry
+
+on:
+  workflow_dispatch:
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Get version from Mason.toml
+      id: version
+      uses: mikefarah/yq@v4
+      with:
+        cmd: yq .brick.version Mason.toml
+    - name: Bump version and push tag
+      id: create_tag
+      uses: mathieudutour/github-tag-action@v6.2
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        custom_tag: ${{ steps.version.outputs.result }}
+        tag_prefix: "v"
+        create_annotated_tag: true
+  push-to-mason-registry:
+    needs: create-tag
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        path: source-repo
+    - name: Get version from Mason.toml
+      id: version
+      uses: mikefarah/yq@v4
+      with:
+        cmd: yq .brick.version source-repo/Mason.toml
+    - name: Get package name
+      id: package_name
+      uses: mikefarah/yq@v4
+      with:
+        cmd: yq .brick.name source-repo/Mason.toml
+    - name: Checkout mason-registry fork
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ vars.REGISTRY_FORK_OWNER }}/mason-registry
+        token: ${{ secrets.MASON_REGISTRY_PAT }}
+        path: mason-registry
+    - name: Create branch and add package
+      run: |
+        cd mason-registry
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config user.name "github-actions[bot]"
+        git checkout -b "${PACKAGE_NAME}-${VERSION}"
+        mkdir -p "Bricks/${PACKAGE_NAME}"
+        cp ../source-repo/Mason.toml "Bricks/${PACKAGE_NAME}/${VERSION}.toml"
+        git add .
+        git commit -m "Add ${PACKAGE_NAME} ${VERSION}"
+      env:
+        VERSION: ${{ steps.version.outputs.result }}
+        PACKAGE_NAME: ${{ steps.package_name.outputs.result }}
+    - name: Push changes
+      uses: ad-m/github-push-action@v1
+      with:
+        github_token: ${{ secrets.MASON_REGISTRY_PAT }}
+        repository: ${{ vars.REGISTRY_FORK_OWNER }}/mason-registry
+        branch: "${{ steps.package_name.outputs.result }}-${{ steps.version.outputs.result }}"
+        directory: mason-registry
+    - name: Create pull request
+      run: >
+        gh pr create
+        --repo chapel-lang/mason-registry
+        --head "${{ vars.REGISTRY_FORK_OWNER }}:${{ steps.package_name.outputs.result }}-${{ steps.version.outputs.result }}"
+        --base master
+        --title "Add ${{ steps.package_name.outputs.result }} ${{ steps.version.outputs.result }}"
+        --body "Add ${{ steps.package_name.outputs.result }} version ${{ steps.version.outputs.result }} to the mason registry"
+      env:
+        GH_TOKEN: ${{ secrets.MASON_REGISTRY_PRS }}

--- a/Mason.toml
+++ b/Mason.toml
@@ -1,7 +1,7 @@
 
 [brick]
 name = "Parquet"
-version = "0.1.0"
+version = "0.1.1"
 type = "library"
 chplVersion = "2.8.0..2.9.0"
 source = "https://github.com/e-kayrakli/Parquet"


### PR DESCRIPTION
### Summary

1. Introduce workflows to automate the minor version bumping and publishing process to the mason registry. 
2. Update the version to 0.1.1 in the configuration file.


### Add GitHub Actions workflows to automate publishing to the mason registry and bumping the version afterward.

`publish.yml` (manual trigger):

1. Creates a git tag from the version in Mason.toml
2. Pushes a branch to the mason-registry fork with the package manifest
4. Opens a PR on chapel-lang/mason-registry

`bump-minor-version.yml` (runs after successful publish, or manually):
- Increments the minor version in Mason.toml and README.md
- Opens a PR with those changes.


Setup required:
1. `MASON_REGISTRY_PAT` secret — needs read/write access to your fork of mason-registry (Contents read/write)
1. `MASON_REGISTRY_PRS` secret — classic PAT with public_repo scope for cross-repo PRs
1. `REGISTRY_FORK_OWNER` repo variable — GitHub username that owns the mason-registry fork

-----

Note for reviewer: Both of these workflows are copied from @jabraham17's packages ([here](https://github.com/jabraham17/CVL/blob/main/.github/workflows/bump-minor-version.yml) and [here](https://github.com/jabraham17/CVL/blob/main/.github/workflows/publish.yml))with some changes:
1. Change env handling:

Change patterns like:

```yml
      run: |
        VERSION="${{ steps.version.outputs.result }}"
        PACKAGE_NAME="${{ steps.package_name.outputs.result }}"
        do something with VERSION and PACKAGE_NAME
```

to 

```yml
      run: |
        do something with VERSION and PACKAGE_NAME
      env:
        VERSION: ${{ steps.version.outputs.result }}
        PACKAGE_NAME: ${{ steps.package_name.outputs.result }}
```


And 

2. use `sed -i` instead of plain `sed` with temp files for changing stuff in place



[Reviewed by @benharsh]