### PR TITLE
Print error from parquet call

### DIFF
--- a/src/Parquet.chpl
+++ b/src/Parquet.chpl
@@ -136,7 +136,7 @@ module Parquet {
       // https://github.com/chapel-lang/chapel/issues/27764
       if err {
         halt(try! "Unhandled error in extern call %s.%s (%i): %s".format(
-                       modName, procName, lineNo, err.message()));
+                       modName, procName, lineNo, err!.message()));
       }
     }
 

--- a/src/Parquet.chpl
+++ b/src/Parquet.chpl
@@ -135,8 +135,8 @@ module Parquet {
       // TODO this should be a thrown error in exitContext.
       // https://github.com/chapel-lang/chapel/issues/27764
       if err {
-        halt(try! "Unhandled error in extern call %s.%s (%i)".format(
-                       modName, procName, lineNo));
+        halt(try! "Unhandled error in extern call %s.%s (%i): %s".format(
+                       modName, procName, lineNo, err));
       }
     }
 

--- a/src/Parquet.chpl
+++ b/src/Parquet.chpl
@@ -136,7 +136,7 @@ module Parquet {
       // https://github.com/chapel-lang/chapel/issues/27764
       if err {
         halt(try! "Unhandled error in extern call %s.%s (%i): %s".format(
-                       modName, procName, lineNo, err));
+                       modName, procName, lineNo, err.message()));
       }
     }
 


### PR DESCRIPTION
Add `err.message()` to the printed message where previously we didn't actually print what the error was.